### PR TITLE
Editable trace div

### DIFF
--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -1130,13 +1130,15 @@ Trace1.onkeydown = function(e) {
     }
     if (e.key == "Tab") {
         // go to the previous/next uncle
-        e.preventDefault()
         foc = sel.focusNode
         if (!foc.closest) foc = foc.parentElement   // it was a textnode
         foc = foc.closest('.dropcell')
         // skip labels
-        foc = e.shiftKey ? foc.previousElementSibling.previousElementSibling : foc.nextElementSibling.nextElementSibling
-        sel.setPosition(foc, 0)
+        try {
+           foc = e.shiftKey ? foc.previousElementSibling.previousElementSibling : foc.nextElementSibling.nextElementSibling
+           sel.setPosition(foc, 0)
+           e.preventDefault()
+        } catch {}   // fallback to normal tab behaviour
     }
 }
 

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -250,7 +250,7 @@
     <a id="github" style="text-decoration: none; color: black; padding: 0px 8px;" href="https://github.com/mzechmeister/csvplotter"><i class="fab fa-github"></i></a>
     <label onclick="this.firstChild.disabled=false"><input id="webgl" type="checkbox" checked onchange="select_columns()" style="display: None;">
     <i class="fas fa-glasses" style="padding: 0px 8px 0px 0px;"></i></label>
-    <label><input id="cbfancy" type="checkbox" checked onchange='document.getElementsByClassName("Traces")[0].classList.toggle("fancy", this.checked); console.log(this.checked)' style="display: None;">
+    <label><input id="cbfancy" type="checkbox" checked onchange='document.getElementById("Traces").classList.toggle("fancy", this.checked)' style="display: None;">
     <i class="fas fa-border-style"></i></label>
     </div>
 </div>
@@ -261,8 +261,8 @@
 </div>
 
 
-<div class="Traces fancy" style="background: white; margin: 5px 0;">
-   <div class="Trace" contenteditable tnum=1 tabIndex=0>
+<div id="Traces" class="fancy" style="background: white; margin: 5px 0;">
+   <div class="Trace" contenteditable tnum=1>
       <image src="https://raw.githubusercontent.com/plotly/plotly-icons/master/src/svg/plot-scatter.svg" class="plotypicon">
       <label><i class="far fa-file"></i></label><span id="url" class="dropcell"><label for="csvFileInput" style="display: inline-block; text-align: left; border: 1px solid #ccc"></label>
       <input id="csvFileInput" type="file" style="display:none" onchange="this.previousElementSibling.textContent = this.previousElementSibling.title = this.files[0].name; dsv(this.files[0], plot_data)" placeholder="Choose file"></span>
@@ -277,7 +277,7 @@
       <label><i class="fa fa-tint"></i></label><span id="cc" class="dropcell color" placeholder="color" onchange="select_columns()"></span>
       <label><i class="fa fa-adjust"></i></label><span id="co" class="dropcell opacity" placeholder="opac" onchange="select_columns()">0.5</span>
    </div>
-   <div class="Trace" tnum=2>
+   <div class="Trace" contenteditable tnum=2>
       <image src="https://raw.githubusercontent.com/plotly/plotly-icons/master/src/svg/plot-line.svg" class="plotypicon">
       <label><i class="fa fa-calculator"></i></label><span id="funcf" class="dropcell func" onchange="empty_func(); draw_func()" placeholder="[::] f(x)  or  x(t), y(t)"></span>
       <label><i class="fa fa-tint"></i></label><span type="search" id="funcc" class="dropcell color rgb" placeholder="color" onchange="empty_func(); draw_func()"></span>
@@ -1098,13 +1098,13 @@ suggest_list = document.getElementById("suggest_list")
 suggest_list.onmouseover = suggest_hover
 suggest_list.onmousedown = suggest_hit
 
-Trace1 = document.getElementsByClassName('Trace')[0]
+Traces = document.getElementById('Traces')
 
-Trace1.oninput = function(e) {
+Traces.oninput = function(e) {
     parseNode(sel.focusNode.parentElement.closest('.dropcell'))
 }
 
-Trace1.onkeydown = function(e) {
+Traces.onkeydown = function(e) {
     if (e.key=="ArrowDown" || e.key=="ArrowUp") {
         if (suggest_list.style.display == "") {   // case: re-entering span
             // same as oninput

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -1164,7 +1164,7 @@ function closest(elem, cls) {
 document.addEventListener("selectionchange", function(e) {
     for (let x of [...document.getElementsByClassName('caretover')])
         x.classList.remove('caretover')
-    let foc = closest(sel.focusNode.parentNode, ".dropcell")
+    let foc = closest(sel.focusNode, ".dropcell")
     foc && foc.classList.add('caretover')
     //posinfo.innerHTML = childIndex(sel.getRangeAt(0))+","+sel.focusOffset
 })

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -1122,9 +1122,7 @@ Traces.onkeydown = function(e) {
     }
     if (e.key == "Tab") {
         // go to the previous/next uncle
-        foc = sel.focusNode
-        if (!foc.closest) foc = foc.parentElement   // it was a textnode
-        foc = foc.closest('.dropcell')
+        foc = closest(sel.focusNode, '.dropcell')
         // skip labels
         try {
            foc = e.shiftKey ? foc.previousElementSibling.previousElementSibling : foc.nextElementSibling.nextElementSibling

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -1122,24 +1122,21 @@ Trace1.onkeydown = function(e) {
         if (multinode || (sel.focusOffset == sel.focusNode.length && !sel.focusNode.nextSibling)) 
             e.preventDefault()
     if (e.key == "Enter") {
-        if (suggest_list.style.display!="" && (hit=document.querySelector('.show.hover'))) {
+        e.preventDefault()
+        if (suggest_list.style.display!="" && (hit=document.querySelector('.show.hover')))
             suggest_hit(hit)
-            e.preventDefault()
-            return true
-        } else {
+        else
             select_columns()    // update plot
-            e.preventDefault()
-        }
     }
     if (e.key == "Tab") {
         // go to the previous/next uncle
+        e.preventDefault()
         foc = sel.focusNode
         if (!foc.closest) foc = foc.parentElement   // it was a textnode
         foc = foc.closest('.dropcell')
         // skip labels
         foc = e.shiftKey ? foc.previousElementSibling.previousElementSibling : foc.nextElementSibling.nextElementSibling
         sel.setPosition(foc, 0)
-        e.preventDefault()
     }
 }
 

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -36,7 +36,7 @@
         text-indent: 15px;
     }
 
-    .dragging.dropcell, .dragging .dropcell, .dropcell:focus-within,  div.func:focus-within  {
+    .dragging.dropcell, .dragging .dropcell, .dropcell.caretover,  div.func:focus-within  {
         box-shadow: 0 0 3px 1px #090;   /* green */
     }
 
@@ -1149,6 +1149,20 @@ function setEndOfContenteditable(elem) {
 }
 
 var sel = window.getSelection()
+
+function closest(elem, cls) {
+    if (!elem.closest) elem = elem.parentNode
+    return elem.closest(cls)
+}
+
+document.addEventListener("selectionchange", function(e) {
+    for (let x of [...document.getElementsByClassName('caretover')])
+        x.classList.remove('caretover')
+    let foc = closest(sel.focusNode.parentNode, ".dropcell")
+    foc && foc.classList.add('caretover')
+    //posinfo.innerHTML = childIndex(sel.getRangeAt(0))+","+sel.focusOffset
+})
+
 
 </script>
 

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -420,21 +420,6 @@ for (cell of document.getElementsByClassName('color')) {
     cell.onchange = (e => colorRestyle(e.target))
 }
 
-for (cell of document.querySelectorAll("dropcell")) {
-    cell.oninput = function(e) {
-        parseNode(this)
-    }
-    cell.onkeeyup = function(e) {
-        if (this.innerText=="\n") {
-            // prevent newline when empyting with backspace or del
-            this.innerText = ""
-        }
-    }
-}
-
-document.getElementById("funcf").onkeyup = function(e) {if (this.innerText=="\n") {this.innerText = ""}; this.onchange()}
-
-
 function handleDragStart(e) {
     add_drop("[tnum='1']")
     e.dataTransfer.effectAllowed = 'move'
@@ -670,15 +655,15 @@ function linspace(start, stop, num, endpoint=true) {
 function empty_func() {
     // a placeholder (function with no data)
     var graph = document.getElementsByClassName("js-plotly-plot")[0]
-    expr1 = document.getElementById("funcf").innerText
+    expr1 = document.getElementById("funcf").innerText.replace("\n", "")
     if (expr1 == "") Plotly.restyle(graph, {'x':[[]], 'y':[[]]}, 1)
 }
 
 function draw_func() {
     var graph = document.getElementsByClassName("js-plotly-plot")[0]
-    expr1 = document.getElementById("funcf").innerText
-    funcc = document.getElementById("funcc").innerText
-    funco = document.getElementById("funco").innerText
+    expr1 = document.getElementById("funcf").innerText.replace("\n", "")
+    funcc = document.getElementById("funcc").innerText.replace("\n", "")
+    funco = document.getElementById("funco").innerText.replace("\n", "")
     if (expr1 != "") {
         try {
             /* expr = new Function("x", "return "+expr1) */
@@ -1104,6 +1089,9 @@ Traces = document.getElementById('Traces')
 
 Traces.oninput = function(e) {
     parseNode(closest(sel.focusNode, '.dropcell'))
+    if (document.getElementById('funcf').contains(sel.focusNode))
+        // aggressive function update
+        document.getElementById('funcf').onchange()
 }
 
 Traces.onkeydown = function(e) {

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -262,7 +262,7 @@
 
 
 <div class="Traces fancy" style="background: white; margin: 5px 0;">
-   <div class="Trace" tnum=1 tabIndex=0>
+   <div class="Trace" contenteditable tnum=1 tabIndex=0>
       <image src="https://raw.githubusercontent.com/plotly/plotly-icons/master/src/svg/plot-scatter.svg" class="plotypicon">
       <label><i class="far fa-file"></i></label><span id="url" class="dropcell"><label for="csvFileInput" style="display: inline-block; text-align: left; border: 1px solid #ccc"></label>
       <input id="csvFileInput" type="file" style="display:none" onchange="this.previousElementSibling.textContent = this.previousElementSibling.title = this.files[0].name; dsv(this.files[0], plot_data)" placeholder="Choose file"></span>
@@ -404,6 +404,9 @@ for (color of Plotly.d3.scale.category10().range()) {
     divcols.append(div)
 }
 
+for (cell of document.querySelectorAll('.Trace label')) {
+    cell.contentEditable = false
+}
 
 for (cell of document.getElementsByClassName('dropcell')) {
     cell.contentEditable = true
@@ -416,7 +419,7 @@ for (cell of document.getElementsByClassName('color')) {
     cell.onchange = (e => colorRestyle(e.target))
 }
 
-for (cell of document.querySelectorAll("[contenteditable]")) {
+for (cell of document.querySelectorAll("dropcell")) {
     cell.oninput = function(e) {
         parseNode(this)
     }
@@ -1095,7 +1098,13 @@ suggest_list = document.getElementById("suggest_list")
 suggest_list.onmouseover = suggest_hover
 suggest_list.onmousedown = suggest_hit
 
-function handle_keydown(e) {
+Trace1 = document.getElementsByClassName('Trace')[0]
+
+Trace1.oninput = function(e) {
+    parseNode(sel.focusNode.parentElement.closest('.dropcell'))
+}
+
+Trace1.onkeydown = function(e) {
     if (e.key=="ArrowDown" || e.key=="ArrowUp") {
         if (suggest_list.style.display == "") {   // case: re-entering span
             // same as oninput
@@ -1111,19 +1120,27 @@ function handle_keydown(e) {
             e.preventDefault()
             return true
         } else {
-            try {this.onchange(e)}
-            finally {return false}   // no newline for Enter press
+            select_columns()    // update plot
+            e.preventDefault()
         }
+    }
+    if (e.key == "Tab") {
+        // go to the previous/next uncle
+        foc = sel.focusNode
+        if (!foc.closest) foc = foc.parentElement   // it was a textnode
+        foc = foc.closest('.dropcell')
+        // skip labels
+        foc = e.shiftKey ? foc.previousElementSibling.previousElementSibling : foc.nextElementSibling.nextElementSibling
+        sel.setPosition(foc, 0)
+        e.preventDefault()
     }
 }
 
 for (item of document.querySelectorAll("[tnum='1'] > span.dropcell")) {
-    item.onkeydown = handle_keydown
     item.onblur = () => {suggest_list.style.display = ""}
 }
 
 for (item of document.querySelectorAll("[tnum='2'] > span.dropcell")) {
-    item.onkeydown = handle_keydown
 }
 
 function setEndOfContenteditable(elem) {

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -404,12 +404,13 @@ for (color of Plotly.d3.scale.category10().range()) {
     divcols.append(div)
 }
 
-for (cell of document.querySelectorAll('.Trace label')) {
+for (cell of document.querySelectorAll('.Trace label,img')) {
     cell.contentEditable = false
 }
 
 for (cell of document.getElementsByClassName('dropcell')) {
     cell.contentEditable = true
+    cell.innerHTML = "<br>"   // allows to focus empty spans
     cell.spellcheck = false
     cell.ondragover = handleDragEnter
     cell.ondrop = handleDrop
@@ -573,8 +574,8 @@ function init_box(colpool) {
 }
 
 function parseCell(cell) {
-    cellHTML = cell.innerHTML
-    cellText = cell.innerText
+    cellHTML = cell.innerHTML.replace(/<br>/g, "")
+    cellText = cell.innerText.replace(/\n/g, "")
     if (cellHTML == +cellHTML) {
         // scalar, e.g. "5"
         result = cellText }
@@ -872,7 +873,7 @@ function parseNode(node) {
         seltext = node.innerText
     curpos = seltext.replace("\n", "").replace("\r", "").length
 
-    let toparse = node.innerText.split("$")
+    let toparse = node.innerText.replace("\n", "").split("$")
     node.innerHTML = toparse.shift()   // Consume the first text. It's "", when string starts with "$".
 
     let curnode = node.firstChild   // a text node
@@ -902,6 +903,7 @@ function parseNode(node) {
     let offset = curpos - sel.toString().length
     sel.extend(curnode || node, offset)
     sel.collapseToEnd()
+    node.append(document.createElement("br"))
     node.focus()   // no effect?
 
     qname && filter_suggests(curnode.parentNode)
@@ -1101,7 +1103,7 @@ suggest_list.onmousedown = suggest_hit
 Traces = document.getElementById('Traces')
 
 Traces.oninput = function(e) {
-    parseNode(sel.focusNode.parentElement.closest('.dropcell'))
+    parseNode(closest(sel.focusNode, '.dropcell'))
 }
 
 Traces.onkeydown = function(e) {
@@ -1114,13 +1116,15 @@ Traces.onkeydown = function(e) {
         suggest_hover_kdb(e)
         return true
     }
-    multinode = sel.anchorNode != sel.focusNode
-    if (e.key == "Backspace")
-        if (multinode || (sel.focusOffset == 0 && !sel.focusNode.previousSibling)) 
+    if (e.key == "Backspace" || e.key == "Delete") {
+        if (closest(sel.anchorNode, ".dropcell") != closest(sel.focusNode, ".dropcell")) {
+            // multinode
             e.preventDefault()
-    if (e.key == "Delete")
-        if (multinode || (sel.focusOffset == sel.focusNode.length && !sel.focusNode.nextSibling)) 
+        } else if (closest(sel.focusNode, ".dropcell").innerText == "\n") {
+            // info("empty node")
             e.preventDefault()
+        }                
+    } 
     if (e.key == "Enter") {
         e.preventDefault()
         if (suggest_list.style.display!="" && (hit=document.querySelector('.show.hover')))
@@ -1166,9 +1170,8 @@ document.addEventListener("selectionchange", function(e) {
         x.classList.remove('caretover')
     let foc = closest(sel.focusNode, ".dropcell")
     foc && foc.classList.add('caretover')
-    //posinfo.innerHTML = childIndex(sel.getRangeAt(0))+","+sel.focusOffset
+    // info(sel.focusNode.nodeName+", "+sel.focusOffset)
 })
-
 
 </script>
 

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -1132,13 +1132,6 @@ Traces.onkeydown = function(e) {
     }
 }
 
-for (item of document.querySelectorAll("[tnum='1'] > span.dropcell")) {
-    item.onblur = () => {suggest_list.style.display = ""}
-}
-
-for (item of document.querySelectorAll("[tnum='2'] > span.dropcell")) {
-}
-
 function setEndOfContenteditable(elem) {
     sel.selectAllChildren(elem)
     sel.collapseToEnd()
@@ -1151,11 +1144,16 @@ function closest(elem, cls) {
     return elem.closest(cls)
 }
 
+focused_dropcell = null
 document.addEventListener("selectionchange", function(e) {
-    for (let x of [...document.getElementsByClassName('caretover')])
-        x.classList.remove('caretover')
     let foc = closest(sel.focusNode, ".dropcell")
-    foc && foc.classList.add('caretover')
+    if (foc != focused_dropcell) {
+        // handle focus change and blur events
+        focused_dropcell && focused_dropcell.classList.remove('caretover')
+        foc && foc.classList.add('caretover')
+        suggest_list.style.display = ""
+        focused_dropcell = foc
+    }
     // info(sel.focusNode.nodeName+", "+sel.focusOffset)
 })
 

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -1114,6 +1114,13 @@ Trace1.onkeydown = function(e) {
         suggest_hover_kdb(e)
         return true
     }
+    multinode = sel.anchorNode != sel.focusNode
+    if (e.key == "Backspace")
+        if (multinode || (sel.focusOffset == 0 && !sel.focusNode.previousSibling)) 
+            e.preventDefault()
+    if (e.key == "Delete")
+        if (multinode || (sel.focusOffset == sel.focusNode.length && !sel.focusNode.nextSibling)) 
+            e.preventDefault()
     if (e.key == "Enter") {
         if (suggest_list.style.display!="" && (hit=document.querySelector('.show.hover'))) {
             suggest_hit(hit)

--- a/csv_plotter.htm
+++ b/csv_plotter.htm
@@ -114,7 +114,7 @@
         flex-grow: 0;
     }
 
-    .dropcell.rgb:not(:hover):not(:focus) {
+    .dropcell.rgb:not(:hover):not(.caretover) {
         /* slowly hide hex string */
         transition: color 1s;
         color: transparent;


### PR DESCRIPTION
The trace is now contenteditable, which closes #6 and #11.
* One can nicely browse through the cells with arrowkeys on keyboard or swiping on spacebar (mobile devices).
* `<br>` somehow handles nicely empty cells for focussing and does not jump over.
* Events like `blur` must be handled with selectionchange.
* Tabbing focussed next cells.